### PR TITLE
feat: add o200k_base encoding support for GPT-4o models

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 Openai's Tiktoken implementation written in Swift. This is basic implementation from ordinary encode/decode.
 
 Supports vocab:
+
 - gpt2 (Same for gpt3)
 - r50k_base
 - p50k_base
 - p50k_edit
 - cl100k_base (gpt-4 and gpt-3.5)
+- o200k_base (gpt-4o, and o1-)
 
 And also supports asian characters and emojis.
 
 Stars are welcome 😊.
 
-## Usage
+##  Usage
 
 ```swift
 let encoder = try await Tiktoken.shared.getEncoding("gpt-4")

--- a/Sources/Tiktoken/Model.swift
+++ b/Sources/Tiktoken/Model.swift
@@ -19,16 +19,36 @@ enum Model {
 
 private extension Model {
     static let MODEL_PREFIX_TO_ENCODING: [String: String] = [
+        "o1-": "o200k_base",
         // chat
+        "chatgpt-4o-": "o200k_base",
+        "gpt-4o-": "o200k_base",  // e.g., gpt-4o-2024-05-13
         "gpt-4-": "cl100k_base",  // e.g., gpt-4-0314, etc., plus gpt-4-32k
         "gpt-3.5-turbo-": "cl100k_base",  // e.g, gpt-3.5-turbo-0301, -0401, etc.
+        "gpt-35-turbo-": "cl100k_base",  // Azure deployment name
+        // fine-tuned
+        "ft:gpt-4": "cl100k_base",
+        "ft:gpt-3.5-turbo": "cl100k_base",
+        "ft:davinci-002": "cl100k_base",
+        "ft:babbage-002": "cl100k_base"
     ]
     
     static let MODEL_TO_ENCODING: [String: String] = [
         // chat
+        "gpt-4o": "o200k_base",
         "gpt-4": "cl100k_base",
         "gpt-3.5-turbo": "cl100k_base",
-        // text
+        "gpt-3.5": "cl100k_base",  // Common shorthand
+        "gpt-35-turbo": "cl100k_base",  // Azure deployment name
+        // base
+        "davinci-002": "cl100k_base",
+        "babbage-002": "cl100k_base",
+        // embeddings
+        "text-embedding-ada-002": "cl100k_base",
+        "text-embedding-3-small": "cl100k_base",
+        "text-embedding-3-large": "cl100k_base",
+        // DEPRECATED MODELS
+        // text (DEPRECATED)
         "text-davinci-003": "p50k_base",
         "text-davinci-002": "p50k_base",
         "text-davinci-001": "r50k_base",
@@ -39,19 +59,17 @@ private extension Model {
         "curie": "r50k_base",
         "babbage": "r50k_base",
         "ada": "r50k_base",
-        // code
+        // code (DEPRECATED)
         "code-davinci-002": "p50k_base",
         "code-davinci-001": "p50k_base",
         "code-cushman-002": "p50k_base",
         "code-cushman-001": "p50k_base",
         "davinci-codex": "p50k_base",
         "cushman-codex": "p50k_base",
-        // edit
+        // edit (DEPRECATED)
         "text-davinci-edit-001": "p50k_edit",
         "code-davinci-edit-001": "p50k_edit",
-        // embeddings
-        "text-embedding-ada-002": "cl100k_base",
-        // old embeddings
+        // old embeddings (DEPRECATED)
         "text-similarity-davinci-001": "r50k_base",
         "text-similarity-curie-001": "r50k_base",
         "text-similarity-babbage-001": "r50k_base",
@@ -64,7 +82,7 @@ private extension Model {
         "code-search-ada-code-001": "r50k_base",
         // open source
         "gpt2": "gpt2",
-        "gpt3": "gpt3",
+        "gpt-2": "gpt2",  // Maintains consistency with gpt-4
     ]
     
     static func findPrefix(with name: String) -> Vocab? {


### PR DESCRIPTION
- Add o200k_base encoding mappings for GPT-4o and o1 models in Model.swift
- Update README to include o200k_base vocabulary support